### PR TITLE
Fix typo

### DIFF
--- a/1.13/usage/validation-and-error-handling/index.html
+++ b/1.13/usage/validation-and-error-handling/index.html
@@ -1273,7 +1273,7 @@ to build a message.</p>
 <p>It is possible to set up a list of exceptions that can be caught by the mapper,
 for instance when using lightweight validation tools like <a href="https://github.com/webmozarts/assert">Webmozart Assert</a>.</p>
 <p>It is advised to use this feature with caution: userland exceptions may contain
-sensible information — for instance an SQL exception showing a part of a query
+sensitive information — for instance an SQL exception showing a part of a query
 should never be allowed. Therefore, only an exhaustive list of carefully chosen
 exceptions should be filtered.</p>
 <div class="highlight"><pre><span></span><code><a id="__codelineno-3-1" name="__codelineno-3-1" href="#__codelineno-3-1"></a><span class="k">final</span> <span class="k">class</span> <span class="nc">SomeClass</span>


### PR DESCRIPTION
Hey, I noticed what looks like a small typo on the documentation.

![image](https://github.com/user-attachments/assets/abe114f7-55c2-4d45-87ec-fd15c3cc9a27)
